### PR TITLE
Fix Replace regex substring bug

### DIFF
--- a/source/FFImageLoading.Svg.Shared/SvgDataResolver.cs
+++ b/source/FFImageLoading.Svg.Shared/SvgDataResolver.cs
@@ -102,7 +102,7 @@ namespace FFImageLoading.Svg.Platform
                     foreach (var map in ReplaceStringMap
                              .Where(v => v.Key.StartsWith("regex:")))
                     {
-                        inputString = Regex.Replace(inputString, map.Key.Substring(0, 6), map.Value);
+                        inputString = Regex.Replace(inputString, map.Key.Substring(6), map.Value);
                     }
 
                     var builder = new StringBuilder(inputString);


### PR DESCRIPTION
FFImageLoading.Svg.Platform.SvgDataResolver.cs#line 105
regex of ReplaceStringMap is not extracted correctly
the text "regex:" would be replaced in the SVG image instead of the regex matches.